### PR TITLE
Racial bonus not added

### DIFF
--- a/modules/characters/client/controllers/characters.client.controller.js
+++ b/modules/characters/client/controllers/characters.client.controller.js
@@ -38,7 +38,7 @@
     vm.getSaveMod = getSaveMod;
     vm.randomizeBackground = randomizeBackground;
     init();
-
+    
     function init() {
       vm.loadedData = dataLoader.loadData(vm.character, Authentication.user);
       vm.skills = characterSources.getSkills();

--- a/modules/characters/client/controllers/characters.client.controller.js
+++ b/modules/characters/client/controllers/characters.client.controller.js
@@ -38,7 +38,7 @@
     vm.getSaveMod = getSaveMod;
     vm.randomizeBackground = randomizeBackground;
     init();
-    
+
     function init() {
       vm.loadedData = dataLoader.loadData(vm.character, Authentication.user);
       vm.skills = characterSources.getSkills();

--- a/modules/characters/client/directives/skills-display.client.directive.js
+++ b/modules/characters/client/directives/skills-display.client.directive.js
@@ -20,8 +20,27 @@
       vm.getSaveMod = getSaveMod;
       vm.getMod = getMod;
 
+      /* When editing/creating */
+      vm.getTempSaveMod = getTempSaveMod;
+      vm.getTempMod = getTempMod;
+      vm.getTempModPoints = getTempModPoints;
+      vm.getTempSkillMod = getTempSkillMod;
+
+
       function getMod(attribute) {
         return toMod(vm.character.attributes[attribute]);
+      }
+
+      function getTempMod(attribute) {
+        if(vm.character.race){
+          return toMod(vm.character.attributes[attribute] + vm.character.race.abilityIncreases[attribute]);
+        }
+      }
+
+      function getTempModPoints(attribute) {
+        if(vm.character.race){
+          return vm.character.attributes[attribute] + vm.character.race.abilityIncreases[attribute];
+        }
       }
 
       function getSaveMod(attribute) {
@@ -34,8 +53,26 @@
         return mod;
       }
 
+      function getTempSaveMod(attribute) {
+        if(!vm.character.playableClass[0].profession) { return 0; }
+
+        var mod = getTempMod(attribute);
+        if(vm.character.playableClass[0].profession.saveProficiencies.indexOf(attribute) > -1) {
+          return getProficiency() + mod;
+        }
+        return mod;
+      }
+
       function getSkillMod(skill, attribute) {
         var mod = toMod(vm.character.attributes[attribute]);
+        if(vm.character.skills.indexOf(skill) > -1 || vm.character.background.generalization.skillProficiencies.indexOf(skill) > -1) {
+          return getProficiency() + mod;
+        }
+        return mod;
+      }
+
+      function getTempSkillMod(skill, attribute) {
+        var mod = getTempMod(attribute);
         if(vm.character.skills.indexOf(skill) > -1 || vm.character.background.generalization.skillProficiencies.indexOf(skill) > -1) {
           return getProficiency() + mod;
         }

--- a/modules/characters/client/views/directives/skills-display.view.html
+++ b/modules/characters/client/views/directives/skills-display.view.html
@@ -7,17 +7,35 @@
   </div>
 
   <div ng-repeat="attribute in vm.skills" class="row list-group-item">
-    <div class="col-sm-3">
-      <b ng-if="vm.character.playableClass[0].profession.saveProficiencies.indexOf(attribute.name) > -1">
-        {{attribute.name}}*
-      </b>
-      <span ng-if="vm.character.playableClass[0].profession.saveProficiencies.indexOf(attribute.name) === -1" ng-bind="attribute.name"></span>
+
+    <div ng-if="!vm.canSelect">
+      <div class="col-sm-3" >
+        <b ng-if="vm.character.playableClass[0].profession.saveProficiencies.indexOf(attribute.name) > -1">
+          {{attribute.name}}*
+        </b>
+        <span ng-if="vm.character.playableClass[0].profession.saveProficiencies.indexOf(attribute.name) === -1" ng-bind="attribute.name"></span>
+      </div>
+      <div class="col-sm-2 text-center">
+        {{vm.character.attributes[attribute.name]}} (<span ng-if="vm.getMod(attribute.name) > 0">+</span>{{vm.getMod(attribute.name)}})
+      </div>
+      <div class="col-sm-2 text-center">
+        <span ng-if="vm.getSaveMod(attribute.name)>0">+</span>{{vm.getSaveMod(attribute.name)}}
+      </div>
     </div>
-    <div class="col-sm-2 text-center">
-      {{vm.character.attributes[attribute.name]}} (<span ng-if="vm.getMod(attribute.name) > 0">+</span>{{vm.getMod(attribute.name)}})
-    </div>
-    <div class="col-sm-2 text-center">
-      <span ng-if="vm.getSaveMod(attribute.name)>0">+</span>{{vm.getSaveMod(attribute.name)}}
+
+    <div ng-if="vm.canSelect">
+      <div class="col-sm-3" ng-if="vm.canSelect">
+        <b ng-if="vm.character.playableClass[0].profession.saveProficiencies.indexOf(attribute.name) > -1">
+          {{attribute.name}}*
+        </b>
+        <span ng-if="vm.character.playableClass[0].profession.saveProficiencies.indexOf(attribute.name) === -1" ng-bind="attribute.name"></span>
+      </div>
+      <div class="col-sm-2 text-center">
+        {{vm.getTempModPoints(attribute.name)}} (<span ng-if="vm.getTempMod(attribute.name) > 0">+</span>{{vm.getTempMod(attribute.name)}})
+      </div>
+      <div class="col-sm-2 text-center">
+        <span ng-if="vm.getSaveMod(attribute.name)>0">+</span>{{vm.getTempSaveMod(attribute.name)}}
+      </div>
     </div>
 
     <!-- Character Sheet Mode -->
@@ -53,11 +71,11 @@
           </div>
           <b ng-if="vm.character.skills.indexOf(skill) > -1 || vm.character.background.generalization.skillProficiencies.indexOf(skill) > -1"
               style="margin-top: 0; margin-bottom: 0;">
-            <div class="col-xs-2"><span ng-if="vm.getSkillMod(skill, attribute.name) >0">+</span>{{vm.getSkillMod(skill, attribute.name)}}</div>
+            <div class="col-xs-2"><span ng-if="vm.getSkillMod(skill, attribute.name) >0">+</span>{{vm.getTempSkillMod(skill, attribute.name)}}</div>
             <div class="col-xs-8 check-no-margin">{{skill}}*</div>
           </b>
           <span ng-if="vm.character.skills.indexOf(skill) === -1 && vm.character.background.generalization.skillProficiencies.indexOf(skill) === -1">
-            <div class="col-xs-2"><span ng-if="vm.getSkillMod(skill, attribute.name) >0">+</span>{{vm.getSkillMod(skill, attribute.name)}}</div>
+            <div class="col-xs-2"><span ng-if="vm.getSkillMod(skill, attribute.name) >0">+</span>{{vm.getTempSkillMod(skill, attribute.name)}}</div>
             <div class="col-xs-8 check-no-margin">{{skill}}</div>
           </span>
         </div>


### PR DESCRIPTION
In the character creation (or character edit), the skills table wasn't showing the correct values for Mods (which cascaded) due to the Racial Bonus being added to the total 'on the fly' in the first view in the page, which used a different controller (rendering this live value inaccessible to the other directive.)

This change allows the directive controlling the table in editable scenarios to take the racial bonus into account.

There is an issue open on this [https://github.com/etkirsch/tolmea/issues/23].